### PR TITLE
Fix README and scripts so that "everything from scratch" runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Automation Code for deploy and manage OpenShift Dedicated in GCP in Pre-Existing
 ### Useful notes before you start
 
 * Follow the guide [here](https://docs.openshift.com/dedicated/osd_install_access_delete_cluster/creating-a-gcp-cluster.html#osd-create-gcp-cluster-ccs_osd-creating-a-cluster-on-gcp) to set up your GCP service account
-* Export the location of your json file using: `export GOOGLE_APPLICATION_CREDENTIALS=$PATH_TO_JSON_FILE`
+* Export the location of your json file using: `export TF_VAR_gcp_sa_file_loc=$PATH_TO_JSON_FILE`
 
 
 * Note: if your ssh key is not `~/.ssh/id_rsa.pub`, set this using:
@@ -26,18 +26,18 @@ cp -pr terraform.tfvars.example terraform.tfvars
 
 ## OSD in GCP building everything from scratch (automation yay!)
 
-* Deploy everything using terraform and osd:
+* Deploy everything using terraform and ocm:
 
 Ensure you have the following installed:
-* `osd` binary
+* `ocm` binary, logged in
 * `jq`
-* `gcloud` binary
+* `gcloud` binary, logged in
 
 * Ensure you have the following exported:
 
 ```bash
 export TF_VAR_clustername=$YOUR_CLUSTER_NAME
-export GCP_SA_FILE=$PATH_TO_YOUR_SA_JSON
+export TF_VAR_gcp_sa_file_loc=$PATH_TO_YOUR_SA_JSON
 ````
 
 Then:

--- a/templates/clusterinstall.tftpl
+++ b/templates/clusterinstall.tftpl
@@ -8,7 +8,7 @@ ocm > /dev/null 2>&1 || echo "Please ensure ocm is installed"
 jq > /dev/null 2>&1 || echo "Please ensure jq is installed"
 
 # Check for OCM connectivity
-ocm get /api/clusters_mgmt/v1/clusters --parameter search="name like '${cluster_name}%'" | jq -re '.items[].name' && {echo 'Cluster seems to exist... please clean it up first or select a new name.'; exit 1; }
+ocm get /api/clusters_mgmt/v1/clusters --parameter search="name like '${cluster_name}%'" | jq -re '.items[].name' && (echo 'Cluster seems to exist... please clean it up first or select a new name.'; exit 1; )
 
 # Check if the GCP SA is valid
 ## Get private key ID


### PR DESCRIPTION
Various minor fixes so that the "building everything from scratch" use case for "make all" runs.

- Fix bash syntax error in cluster install script
- Correct the documented name of the environment variable that should point to the GCP application credentials file
- Correct the name of the required binary to "ocm" from "osd"
- Document that "ocm" and "gcloud" must be logged in before running