### PR TITLE
Add the option to use Workload Identity Federation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,28 @@
 
 Automation Code for deploy and manage OpenShift Dedicated in GCP in Pre-Existing VPCs & Private Mode
 
-### Useful notes before you start
+### Authentication
 
-* Follow the guide [here](https://docs.openshift.com/dedicated/osd_install_access_delete_cluster/creating-a-gcp-cluster.html#osd-create-gcp-cluster-ccs_osd-creating-a-cluster-on-gcp) to set up your GCP service account
-* Export the location of your json file using: `export TF_VAR_gcp_sa_file_loc=$PATH_TO_JSON_FILE`
+Pick one of two options for the installer and cluster to access GCP resources in your account, Workload Identity Federation, or Service Account.
 
+#### Workload Identity Federation
 
-* Note: if your ssh key is not `~/.ssh/id_rsa.pub`, set this using:
+[Workload Identity Federation](https://docs.openshift.com/dedicated/osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.html#workload-identity-federation-overview_osd-creating-a-cluster-on-gcp-with-workload-identity-federation) is the preferred method of authentication that uses short-lived credentials.
 
-```bash
-export TF_VAR_bastion_key_loc=$PATH_TO_PUBLIC_KEY
-```
+1. Follow the general [Required customer procedure](https://docs.openshift.com/dedicated/osd_planning/gcp-ccs.html#ccs-gcp-customer-procedure_gcp-ccs)
+1. Follow the specific [Workload Identity Federation authentication type procedure](https://docs.openshift.com/dedicated/osd_planning/gcp-ccs.html#ccs-gcp-customer-procedure-wif_gcp-ccs)
+1. Set the `gcp_authentication_type` Terraform variable using `export TF_VAR_gcp_authentication_type=workload_identity_federation`.
+1. Optionally, if you have configured a bastion, and your ssh key is not `~/.ssh/id_rsa.pub`, set its location using ` export TF_VAR_bastion_key_loc=$PATH_TO_PUBLIC_KEY`
+
+#### Service Account
+
+[Service Account](https://docs.openshift.com/dedicated/osd_gcp_clusters/creating-a-gcp-cluster-sa.html#service-account-auth-overview_osd-creating-a-cluster-on-gcp-sa) authentication uses a public/private keypair with broader permissions than WIF.
+
+1. Follow the general [Required customer procedure](https://docs.openshift.com/dedicated/osd_planning/gcp-ccs.html#ccs-gcp-customer-procedure_gcp-ccs)
+1. Follow the specific [Service account authentication type procedure](https://docs.openshift.com/dedicated/osd_planning/gcp-ccs.html#ccs-gcp-customer-procedure-sa_gcp-ccs)
+1. Export the location of your `osd-ccs-admin` service account key json file using `export TF_VAR_gcp_sa_file_loc=$PATH_TO_JSON_FILE`
+1. Set the `gcp_authentication_type` Terraform variable using `export TF_VAR_gcp_authentication_type=service_account`.
+1. Optionally, if you have configured a bastion, and your ssh key is not `~/.ssh/id_rsa.pub`, set its location using ` export TF_VAR_bastion_key_loc=$PATH_TO_PUBLIC_KEY`
 
 ## OSD in GCP in Pre-Existing VPCs / Subnets (ideally use the terraform below)
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Pick one of two options for the installer and cluster to access GCP resources in
 * Copy and modify the tfvars file in order to custom to your scenario
 
 ```bash
-cp -pr terraform.tfvars.example terraform.tfvars
+cp -pr configuration/tfvars/terraform.tfvars.example configuration/tfvars/terraform.tfvars
 ```
 
 ## OSD in GCP building everything from scratch (automation yay!)
@@ -40,7 +40,7 @@ cp -pr terraform.tfvars.example terraform.tfvars
 * Deploy everything using terraform and ocm:
 
 Ensure you have the following installed:
-* `ocm` binary, logged in
+* `ocm` binary, at least version 1.0.3, logged in
 * `jq`
 * `gcloud` binary, logged in
 

--- a/configuration/tfvars/terraform.tfvars.example
+++ b/configuration/tfvars/terraform.tfvars.example
@@ -16,3 +16,5 @@ gcp_azs = [
 ]
 
 gcp_region = "us-west1"
+
+gcp_authentication_type = "workload_identity_federation"

--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,7 @@ resource "shell_script" "cluster_install" {
         gcp_sa_file_loc         = var.gcp_sa_file_loc
         gcp_authentication_type = var.gcp_authentication_type
         wif_config_name         = "${var.clustername}-wif"
+        osd_gcp_private         = var.osd_gcp_private
     })
     delete = templatefile(
       "${path.module}/templates/clusterdestroy.tftpl",

--- a/main.tf
+++ b/main.tf
@@ -25,12 +25,14 @@ resource "shell_script" "cluster_install" {
     create = templatefile(
       "${path.module}/templates/clusterinstall.tftpl",
       {
-        cluster_name         = var.clustername
-        vpc_name             = google_compute_network.vpc_network.name
-        control_plane_subnet = google_compute_subnetwork.vpc_subnetwork_masters.name
-        compute_subnet       = google_compute_subnetwork.vpc_subnetwork_workers.name
-        gcp_region           = var.gcp_region
-        gcp_sa_file_loc      = var.gcp_sa_file_loc
+        cluster_name            = var.clustername
+        vpc_name                = google_compute_network.vpc_network.name
+        control_plane_subnet    = google_compute_subnetwork.vpc_subnetwork_masters.name
+        compute_subnet          = google_compute_subnetwork.vpc_subnetwork_workers.name
+        gcp_region              = var.gcp_region
+        gcp_sa_file_loc         = var.gcp_sa_file_loc
+        gcp_authentication_type = var.gcp_authentication_type
+        wif_config_name         = "${var.clustername}-wif"
     })
     delete = templatefile(
       "${path.module}/templates/clusterdestroy.tftpl",

--- a/templates/clusterinstall.tftpl
+++ b/templates/clusterinstall.tftpl
@@ -10,18 +10,27 @@ jq > /dev/null 2>&1 || echo "Please ensure jq is installed"
 # Check for OCM connectivity
 ocm get /api/clusters_mgmt/v1/clusters --parameter search="name like '${cluster_name}%'" | jq -re '.items[].name' && (echo 'Cluster seems to exist... please clean it up first or select a new name.'; exit 1; )
 
-# Check if the GCP SA is valid
-## Get private key ID
-export PRIV_KEY_ID=$(cat ${gcp_sa_file_loc} | jq -r '.private_key_id')
-curl -s $(cat ${gcp_sa_file_loc} | jq -r '.client_x509_cert_url') | jq -re --arg PRIV_KEY_ID "$PRIV_KEY_ID" '.[$PRIV_KEY_ID]' || echo 'Your service account specified at ${gcp_sa_file_loc} seems to be invalid or expired. Please check and try again'
+if [[ '${gcp_authentication_type}' == 'service_account' ]]; then
+  # Check if the GCP SA is valid
+  ## Get private key ID
+  export PRIV_KEY_ID=$(cat ${gcp_sa_file_loc} | jq -r '.private_key_id')
+  curl -s $(cat ${gcp_sa_file_loc} | jq -r '.client_x509_cert_url') | jq -re --arg PRIV_KEY_ID "$PRIV_KEY_ID" '.[$PRIV_KEY_ID]' || echo 'Your service account specified at ${gcp_sa_file_loc} seems to be invalid or expired. Please check and try again'
+
+  authentication_param_name='--service-account-file'
+  authentication_param_value='${gcp_sa_file_loc}'
+else # workload identity federation
+  authentication_param_name='--wif-config'
+  authentication_param_value='${wif_config_name}'
+fi
 
 # Create the cluster
+echo "Creating cluster with $authentication_param_name $authentication_param_value"
 ocm create cluster ${cluster_name} --provider gcp \
                 --debug \
                 --vpc-name ${vpc_name} \
                 --region ${gcp_region} \
                 --control-plane-subnet ${control_plane_subnet} \
                 --compute-subnet ${compute_subnet} \
-                --service-account-file ${gcp_sa_file_loc} \
+                "$authentication_param_name" "$authentication_param_value" \
                 --ccs
 

--- a/templates/clusterinstall.tftpl
+++ b/templates/clusterinstall.tftpl
@@ -23,8 +23,13 @@ else # workload identity federation
   authentication_param_value='${wif_config_name}'
 fi
 
+if [[ '${osd_gcp_private}' == 'true' ]]; then
+  private_flag='--private'
+else
+  private_flag=''
+fi
+
 # Create the cluster
-echo "Creating cluster with $authentication_param_name $authentication_param_value"
 ocm create cluster ${cluster_name} --provider gcp \
                 --debug \
                 --vpc-name ${vpc_name} \
@@ -32,5 +37,5 @@ ocm create cluster ${cluster_name} --provider gcp \
                 --control-plane-subnet ${control_plane_subnet} \
                 --compute-subnet ${compute_subnet} \
                 "$authentication_param_name" "$authentication_param_value" \
+                $private_flag \
                 --ccs
-

--- a/templates/wifcreate.tftpl
+++ b/templates/wifcreate.tftpl
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -x
+
+# Check for OCM installation
+ocm > /dev/null 2>&1 || echo "Please ensure ocm is installed"
+
+ocm gcp create wif-config --name ${wif_config_name} --project ${gcp_project}
+# Newly-created wif-configs can take some time before they are valid
+sleep 120
+ocm gcp verify wif-config ${wif_config_name}

--- a/templates/wifdelete.tftpl
+++ b/templates/wifdelete.tftpl
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -x
+
+# Check for OCM installation
+ocm > /dev/null 2>&1 || echo "Please ensure ocm is installed"
+
+# Consider it a success and don't attempt to delete if wif-config already does not exist.
+# This handles the case where the wif config changes or is deleted outside of Terraform
+# and Terraform wants to delete and recreate it, because it detects a change.
+ocm gcp describe wif-config ${wif_config_name} || exit 0
+
+ocm gcp delete wif-config ${wif_config_name}

--- a/templates/wifread.tftpl
+++ b/templates/wifread.tftpl
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -x
+
+# Check for OCM installation
+ocm > /dev/null 2>&1 || echo "Please ensure ocm is installed"
+
+# Format colon-separated lines into a JSON object that the shell provider can read
+ocm gcp describe wif-config ${wif_config_name}  | jq -R --slurp 'split("\n") |map(select(length>0)) | map(split(":\\s+"; null)) | map( {(.[0]): .[1]} ) | reduce .[] as $item ({}; . * $item)'

--- a/variables.tf
+++ b/variables.tf
@@ -92,3 +92,13 @@ variable "only_deploy_infra_no_osd" {
   type        = bool
   default     = false
 }
+
+variable "gcp_authentication_type" {
+  description = "How the installer and cluster should authenticate with GCP. Either 'service_account' or 'workload_identity_federation'"
+  type        = string
+  default     = "service_account"
+  validation {
+    condition     = contains(["service_account", "workload_identity_federation"], var.gcp_authentication_type)
+    error_message = "Valid values for gcp_authentication_type are either 'service_account' or workload_identity_federation'."
+  }
+}


### PR DESCRIPTION
Since Workload Identity Federation is the preferred auth type for OSD-GCP clusters, add the ability to use it. Behavior still defaults to Service Account for backward compatibility, but new projects that copy `terraform.tfvars.example` will get WIF. This behavior is controlled by a new `gcp_authentication_type` variable.

Add a new shell resource to manage the wif-config. This includes a "read" script (which saves the JSON-ified output of `ocm gcp wif-config describe` in Terraform state) to mostly make Terraform behave the way users would expect (in other words, preventing Terraform from wanting to delete/create the wif-config on every run).

Improve documentation for both the WIF and SA options.